### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
       "author": "Jacques, Josue, Rajilsaj",
       "license": "MIT",
       "devDependencies": {                                                                                                                                                  
-	 "karma": "^0.12.16",
+	 "karma": "^6.3.14",
 	 "karma-chrome-launcher": "^0.1.4",
 	 "karma-firefox-launcher": "^0.1.3",
 	 "karma-jasmine": "~0.1.0",
@@ -39,7 +39,7 @@
 	 "http-server": "^0.6.1",
 	 "tmp": "0.0.23",
 	 "bower": "^1.3.1",
-	 "shelljs": "^0.2.6"
+	 "shelljs": "^0.8.5"
       },
       "bugs": {
 	 "url": "https://github.com/CongoLUG/website/issues"


### PR DESCRIPTION
### Issue
<img width="612" alt="Screenshot 2023-09-26 at 9 29 11 AM" src="https://github.com/CongoLUG/website/assets/2589171/e3ceb85c-0102-4823-9b0d-1a2df5d0f9f1">


### Description
This PR updates dependencies to remove GitHub security alert digest on Congo LUG Website  project.

### Result
No more warning for the security alert on website project due to Karma and shelljs dependencies.